### PR TITLE
Fix spacing around rawhtml shortcode

### DIFF
--- a/layouts/shortcodes/rawhtml.html
+++ b/layouts/shortcodes/rawhtml.html
@@ -1,2 +1,2 @@
 <!-- raw html -->
-{{.Inner}}
+{{- .Inner }}


### PR DESCRIPTION
Removes line break from generated HTML output of `{{< rawhtml >}}` shortcode. This line break renders in browsers as an unwanted space.


## PR Checklist

- [ ] This change adds/updates translations and I have used the [template present here](https://github.com/adityatelange/hugo-PaperMod/wiki/Translations#want-to-add-your-language-).
- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have verified that the code works as described/as intended.
- [ ] This change adds a Social Icon which has a permissive license to use it.
- [X] This change **does not** include any CDN resources/links.
- [X] This change **does not** include any unrelated scripts such as bash and python scripts.
- [ ] This change updates the overridden internal templates from HUGO's repository.

---

P.S. You probably want to remove/edit the PR template from PaperMod.