### PR TITLE
Remove target="_blank" from links

### DIFF
--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -6,7 +6,7 @@
     {{- $addLink := (and site.Params.cover.linkFullImages (not $.IsHome)) }}
     {{- $cover := (.Resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
     {{- if $cover -}}{{/* i.e it is present in page bundle */}}
-        {{- if $addLink }}<a href="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" target="_blank"
+        {{- if $addLink }}<a href="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}"
             rel="noopener noreferrer">{{ end -}}
         {{- $sizes := (slice "360" "480" "720" "1080" "1500") }}
         {{- $processableFormats := (slice "jpg" "jpeg" "png" "tif" "bmp" "gif") -}}
@@ -26,7 +26,7 @@
         <img loading="lazy" src="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" alt="{{ $alt }}">
         {{- end }}
     {{- else }}{{/* For absolute urls and external links, no img processing here */}}
-        {{- if $addLink }}<a href="{{ (.Params.cover.image) | absURL }}" target="_blank"
+        {{- if $addLink }}<a href="{{ (.Params.cover.image) | absURL }}"
             rel="noopener noreferrer">{{ end -}}
             <img loading="lazy" src="{{ (.Params.cover.image) | absURL }}" alt="{{ $alt }}">
     {{- end }}

--- a/layouts/partials/edit_post.html
+++ b/layouts/partials/edit_post.html
@@ -2,7 +2,7 @@
 {{- $fileUrlPath := path.Join .File.Path }}
 
 {{- if or .Params.author site.Params.author (.Param "ShowReadingTime") (not .Date.IsZero) .IsTranslated }}&nbsp;|&nbsp;{{- end -}}
-<a href="{{ .Params.editPost.URL | default site.Params.editPost.URL }}{{ if .Params.editPost.appendFilePath | default ( site.Params.editPost.appendFilePath | default false ) }}/{{ $fileUrlPath }}{{ end }}" rel="noopener noreferrer" target="_blank">
+<a href="{{ .Params.editPost.URL | default site.Params.editPost.URL }}{{ if .Params.editPost.appendFilePath | default ( site.Params.editPost.appendFilePath | default false ) }}/{{ $fileUrlPath }}{{ end }}" rel="noopener noreferrer">
     {{- .Params.editPost.Text | default (site.Params.editPost.Text | default (i18n "edit_post" | default "Edit")) -}}
 </a>
 {{- end }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -7,8 +7,8 @@
     {{- end }}
     <span>
         - Powered by
-        <a href="https://gohugo.io/" rel="noopener noreferrer" target="_blank">Hugo</a> &
-        <a href="https://github.com/Wonderfall/hugo-WonderMod/" rel="noopener" target="_blank">WonderMod</a>
+        <a href="https://gohugo.io/" rel="noopener noreferrer">Hugo</a> &
+        <a href="https://github.com/Wonderfall/hugo-WonderMod/" rel="noopener">WonderMod</a>
     </span>
 </footer>
 {{- end }}

--- a/layouts/partials/post_canonical.html
+++ b/layouts/partials/post_canonical.html
@@ -4,6 +4,6 @@
 {{- if or .Params.author site.Params.author (.Param "ShowReadingTime") (not .Date.IsZero) .IsTranslated (or .Params.editPost.URL site.Params.editPost.URL) }}&nbsp;|&nbsp;{{- end -}}
 <span>
     {{- (site.Params.CanonicalLinkText | default .Params.CanonicalLinkText) | default "Originally published at" -}}
-    &nbsp;<a href="{{ trim .Params.canonicalURL " " }}" title="{{ trim .Params.canonicalURL " " }}" target="_blank" rel="noopener noreferrer">{{ $url.Host }}</a>
+    &nbsp;<a href="{{ trim .Params.canonicalURL " " }}" title="{{ trim .Params.canonicalURL " " }}" rel="noopener noreferrer">{{ $url.Host }}</a>
 </span>
 {{- end }}

--- a/layouts/partials/share_icons.html
+++ b/layouts/partials/share_icons.html
@@ -15,7 +15,7 @@
 
 <div class="share-buttons">
     {{- if (cond ($custom) (in $ShareButtons "twitter") (true)) }}
-    <a target="_blank" rel="noopener noreferrer" aria-label="share {{ $title | plainify }} on twitter"
+    <a rel="noopener noreferrer" aria-label="share {{ $title | plainify }} on twitter"
         href="https://twitter.com/intent/tweet/?text={{ $title }}&amp;url={{ $pageurl }}&amp;hashtags={{- $.Scratch.Get "tags" -}}">
         <svg version="1.1" viewBox="0 0 512 512" xml:space="preserve" height="30px" width="30px" fill="currentColor">
             <path
@@ -24,7 +24,7 @@
     </a>
     {{- end }}
     {{- if (cond ($custom) (in $ShareButtons "linkedin") (true)) }}
-    <a target="_blank" rel="noopener noreferrer" aria-label="share {{ $title | plainify }} on linkedin"
+    <a rel="noopener noreferrer" aria-label="share {{ $title | plainify }} on linkedin"
         href="https://www.linkedin.com/shareArticle?mini=true&amp;url={{ $pageurl }}&amp;title={{ $title }}&amp;summary={{ $title }}&amp;source={{ $pageurl }}">
         <svg version="1.1" viewBox="0 0 512 512" xml:space="preserve" height="30px" width="30px" fill="currentColor">
             <path
@@ -33,7 +33,7 @@
     </a>
     {{- end }}
     {{- if (cond ($custom) (in $ShareButtons "reddit") (true)) }}
-    <a target="_blank" rel="noopener noreferrer" aria-label="share {{ $title | plainify }} on reddit"
+    <a rel="noopener noreferrer" aria-label="share {{ $title | plainify }} on reddit"
         href="https://reddit.com/submit?url={{ $pageurl }}&title={{ $title }}">
         <svg version="1.1" viewBox="0 0 512 512" xml:space="preserve" height="30px" width="30px" fill="currentColor">
             <path
@@ -42,7 +42,7 @@
     </a>
     {{- end }}
     {{- if (cond ($custom) (in $ShareButtons "facebook") (true)) }}
-    <a target="_blank" rel="noopener noreferrer" aria-label="share {{ $title | plainify }} on facebook"
+    <a rel="noopener noreferrer" aria-label="share {{ $title | plainify }} on facebook"
         href="https://facebook.com/sharer/sharer.php?u={{ $pageurl }}">
         <svg version="1.1" viewBox="0 0 512 512" xml:space="preserve" height="30px" width="30px" fill="currentColor">
             <path
@@ -51,7 +51,7 @@
     </a>
     {{- end }}
     {{- if (cond ($custom) (in $ShareButtons "whatsapp") (true)) }}
-    <a target="_blank" rel="noopener noreferrer" aria-label="share {{ $title | plainify }} on whatsapp"
+    <a rel="noopener noreferrer" aria-label="share {{ $title | plainify }} on whatsapp"
         href="https://api.whatsapp.com/send?text={{ $title }}%20-%20{{ $pageurl }}">
         <svg version="1.1" viewBox="0 0 512 512" xml:space="preserve" height="30px" width="30px" fill="currentColor">
             <path
@@ -60,7 +60,7 @@
     </a>
     {{- end }}
     {{- if (cond ($custom) (in $ShareButtons "telegram") (true)) }}
-    <a target="_blank" rel="noopener noreferrer" aria-label="share {{ $title | plainify }} on telegram"
+    <a rel="noopener noreferrer" aria-label="share {{ $title | plainify }} on telegram"
         href="https://telegram.me/share/url?text={{ $title }}&amp;url={{ $pageurl }}">
         <svg version="1.1" xml:space="preserve" viewBox="2 2 28 28" height="30px" width="30px" fill="currentColor">
             <path

--- a/layouts/partials/social_icons.html
+++ b/layouts/partials/social_icons.html
@@ -1,6 +1,6 @@
 <div class="social-icons">
     {{- range . }}
-    <a href="{{ trim .url " " }}" target="_blank" rel="noopener noreferrer me" title="{{ (.title | default .name) | title }}">
+    <a href="{{ trim .url " " }}" rel="noopener noreferrer me" title="{{ (.title | default .name) | title }}">
         {{ partial "svg.html" . }}
     </a>
     {{- end }}


### PR DESCRIPTION
Can I convince you to remove `target="_blank"` from all the links on the site? :)

Forcing links to open as new tabs is equivalent to pop-ups in the browser security model, so I'd have to add `allow-popups` to my CSP `sandbox` directive to use this theme. Plus target blank is just bad UX. No worries if you don't want to merge this, it would just save me the trouble of having to maintain _my own_ fork when yours already does everything else I want my PaperMod site to do.