### PR TITLE
Hide lang switch separator if only a single lang is used

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -72,24 +72,26 @@
 
                 {{- $lang := .Lang}}
                 {{- $separator := or $label_text (not site.Params.disableThemeToggle)}}
-                {{- with site.Home.AllTranslations }}
-                <ul class="lang-switch">
-                    {{- if $separator }}<li>|</li>{{ end }}
-                    {{- range . -}}
-                    {{- if ne $lang .Lang }}
-                    <li>
-                        <a href="{{- .Permalink -}}" title="{{ .Language.Params.languageAltTitle | default (.Language.LanguageName | emojify) | default (.Lang | title) }}"
-                            aria-label="{{ .Language.LanguageName | default (.Lang | title) }}">
-                            {{- if (and site.Params.displayFullLangName (.Language.LanguageName)) }}
-                            {{- .Language.LanguageName | emojify -}}
-                            {{- else }}
-                            {{- .Lang | title -}}
-                            {{- end -}}
-                        </a>
-                    </li>
-                    {{- end -}}
-                    {{- end}}
-                </ul>
+                {{- if gt (len site.Home.AllTranslations) 1 }}
+                    {{ with site.Home.AllTranslations }}
+                    <ul class="lang-switch">
+                        {{- if $separator }}<li>|</li>{{ end }}
+                        {{- range . -}}
+                        {{- if ne $lang .Lang }}
+                        <li>
+                            <a href="{{- .Permalink -}}" title="{{ .Language.Params.languageAltTitle | default (.Language.LanguageName | emojify) | default (.Lang | title) }}"
+                                aria-label="{{ .Language.LanguageName | default (.Lang | title) }}">
+                                {{- if (and site.Params.displayFullLangName (.Language.LanguageName)) }}
+                                {{- .Language.LanguageName | emojify -}}
+                                {{- else }}
+                                {{- .Lang | title -}}
+                                {{- end -}}
+                            </a>
+                        </li>
+                        {{- end -}}
+                        {{- end}}
+                    </ul>
+                    {{- end }}
                 {{- end }}
             </div>
         </div>


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

A language switch separator is displayed even if a website has a single language only. This fixes it by checking for `AllTranslations` size before adding the `<ul class="lang-switch">` element.

Before:
<img width="187" alt="Screenshot 2024-04-25 at 6 05 45 PM" src="https://github.com/Wonderfall/hugo-WonderMod/assets/1702435/5599f895-37b6-4c6d-89e7-64e5163e99e1">

After:
<img width="190" alt="Screenshot 2024-04-25 at 6 05 35 PM" src="https://github.com/Wonderfall/hugo-WonderMod/assets/1702435/a67f327d-9d28-486e-b8e2-445730baf755">

Note that I have absolutely no experience with Golang, hopefully the is up to the standards.

## PR Checklist

- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [x] This change **does not** include any CDN resources/links.
- [x] This change **does not** include any unrelated scripts such as bash and python scripts.
